### PR TITLE
Remove client_id

### DIFF
--- a/src/Domainr.php
+++ b/src/Domainr.php
@@ -18,7 +18,7 @@ class Domainr {
   const BASE_URI = "https://api.domainr.com/v1";
   
   // Client ID. See https://github.com/kflorence/domainr-php/issues/2
-  const CLIENT_ID = "php_kflorence";
+  const CLIENT_ID = "{your-mashape-key}";
 
   // Contains all the valid methods for each API
   private $apis = array(


### PR DESCRIPTION
Due to API abuse, we're locking these down further. Details in our [API documentation](http://domainr.build/docs/authentication).